### PR TITLE
Add static public camera dashboard with AI-style tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,209 +1,26 @@
-Contents
-Introduction
-1.1 Contributions
-1.2 Summary of Evaluation Results
+# Public Camera Dashboard (AI-assisted tagging)
 
-Approach
-2.1 Overview
-2.2 HPD-Transformer: Hybrid Parsing-Density Architecture
-2.2.1 Parsing Module: Structured Reasoning
-2.2.2 Density Module: Uncertainty-Aware Predictions
-2.2.3 Sparse Mixture of Experts (MoE): Domain-Specialized Computation
-2.3 Reinforcement Learning from Human Feedback (RLHF)
-2.3.1 Reward Modeling
-2.3.2 Training Template
-2.3.3 Performance and Self-Evolution
-2.4 Knowledge Distillation: Empowering Smaller Models
-2.4.1 Distillation from Teacher Models
-2.4.2 Cross-Domain Adaptation
+A simple, local-first dashboard to track and view legally accessible public camera links.
 
-Experiments
-3.1 HPD-Transformer Evaluation
-3.1.1 Benchmark Results (MMLU, CoNLL, Wikitext)
-3.1.2 Comparison to DeepSeek-V3 and GPT-4
-3.2 Distilled Model Evaluation
-3.2.1 Performance on Edge Devices
-3.2.2 Energy Efficiency Metrics
+## What it does
 
-Discussion
-4.1 Hybrid Reasoning vs. Monolithic Models
-4.2 Unsuccessful Attempts
-4.2.1 Challenges in Long-Context Parsing
-4.2.2 Cold Start for New Domains
+- Lets you save camera links (name, location, notes).
+- Adds lightweight AI-style tags from keywords in your metadata.
+- Embeds previews for common stream URLs and YouTube links.
+- Stores camera list in your browser (`localStorage`).
 
-Conclusion, Limitations, and Future Work
-A. Contributions and Acknowledgments
+> Use only cameras you are authorized to access or links explicitly shared for public viewing.
 
-1. Introduction
-The HPD-Transformer is a novel hybrid AI model designed to bridge the gap between structured parsing and probabilistic reasoning. By combining rule-based logic with uncertainty-aware predictions, the HPD-Transformer achieves state-of-the-art performance in specialized domains while maintaining energy efficiency and scalability.
+## Run locally
 
-1.1 Contributions
-Hybrid Architecture: Integrates parsing and density estimation into a single framework.
+```bash
+python3 -m http.server 8000
+```
 
-Sparse MoE: Reduces computational costs by activating only domain-specific experts.
+Open: `http://localhost:8000`
 
-Energy Efficiency: Achieves 60% lower inference costs than DeepSeek-V3 and GPT-4.
+## Next upgrades (if you want a full AI scraper)
 
-Real-Time Adaptability: Supports online learning for dynamic environments.
-
-1.2 Summary of Evaluation Results
-MMLU Accuracy: 82% (vs. DeepSeek-V3’s 79%).
-
-Inference Cost: 
-0.001
-p
-e
-r
-q
-u
-e
-r
-y
-(
-v
-s
-.
-0.001perquery(vs.0.002 for DeepSeek-V3).
-
-Training CO2 Emissions: 50 kg (vs. 150 kg for DeepSeek-V3).
-
-2. Approach
-2.1 Overview
-The HPD-Transformer combines three core components:
-
-Parsing Module: Lightweight Performer layers for syntactic/semantic analysis.
-
-Density Module: Bayesian neural networks for uncertainty quantification.
-
-Sparse MoE: 32 domain-specific experts with top-2 routing for efficiency.
-
-2.2 HPD-Transformer: Hybrid Parsing-Density Architecture
-2.2.1 Parsing Module:
-
-Extracts dependency trees, entity relationships, and semantic roles.
-
-Uses efficient attention mechanisms (Performer) for O(n) complexity.
-
-2.2.2 Density Module:
-
-Outputs confidence scores and probability distributions.
-
-Flags low-confidence predictions for human review.
-
-2.2.3 Sparse MoE:
-
-Activates only relevant experts per input (e.g., medical, legal).
-
-Reduces computation by 50% compared to dense transformers.
-
-2.3 Reinforcement Learning from Human Feedback (RLHF)
-2.3.1 Reward Modeling:
-
-Trains on human preferences for correctness and clarity.
-
-2.3.2 Training Template:
-
-Uses Proximal Policy Optimization (PPO) for fine-tuning.
-
-2.3.3 Performance and Self-Evolution:
-
-Achieves 12% improvement in user satisfaction scores.
-
-Supports continuous learning via user feedback.
-
-2.4 Knowledge Distillation
-2.4.1 Distillation from Teacher Models:
-
-Transfers knowledge from GPT-4 and DeepSeek-V3.
-
-2.4.2 Cross-Domain Adaptation:
-
-Fine-tunes on domain-specific datasets (e.g., healthcare, finance).
-
-3. Experiments
-3.1 HPD-Transformer Evaluation
-3.1.1 Benchmark Results:
-
-MMLU: 82% accuracy (vs. 79% for DeepSeek-V3).
-
-CoNLL-2003: 92.3 F1-score for named entity recognition.
-
-Wikitext-103: 18.5 perplexity.
-
-3.1.2 Comparison to Baselines:
-
-Outperforms GPT-4 and DeepSeek-V3 in specialized tasks.
-
-3.2 Distilled Model Evaluation
-3.2.1 Performance on Edge Devices:
-
-Runs on Raspberry Pi with <1 GB memory.
-
-3.2.2 Energy Efficiency Metrics:
-
-80% lower CO2 emissions than comparable models.
-
-4. Discussion
-4.1 Hybrid Reasoning vs. Monolithic Models
-Advantages:
-
-Combines deterministic parsing with probabilistic reasoning.
-
-Achieves higher accuracy in niche domains.
-
-Limitations:
-
-Struggles with long-context inputs (>8k tokens).
-
-4.2 Unsuccessful Attempts
-4.2.1 Challenges in Long-Context Parsing:
-
-Performance degrades beyond 8k tokens.
-
-4.2.2 Cold Start for New Domains:
-
-Requires significant fine-tuning for rare domains.
-
-5. Conclusion, Limitations, and Future Work
-Conclusion:
-The HPD-Transformer sets a new standard for hybrid AI models, combining precision, efficiency, and adaptability.
-
-Limitations:
-
-Limited context length.
-
-High compute requirements for training.
-
-Future Work:
-
-Expand context window to 32k tokens.
-
-Add multi-modal support (text + images).
-
-A. Contributions and Acknowledgments
-Contributions:
-
-Dr. RAMI: Lead architect and researcher.
-
-HPD AI Labs: Development and deployment.
-
-Acknowledgments:
-
-Hugging Face for open-source tools.
-
-NVIDIA for GPU support.## Hi there 👋
-
-<!--
-**ramishaheen/ramishaheen** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
-Here are some ideas to get you started:
-
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+- Add a backend crawler for **approved** directories/APIs of public webcams.
+- Add OpenCV/YOLO detection (vehicles, crowding, motion).
+- Add alerting rules, map layers, and user authentication.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,136 @@
+const STORAGE_KEY = "camera-dashboard-v1";
+
+function suggestTags(camera) {
+  const text = `${camera.name} ${camera.location} ${camera.url}`.toLowerCase();
+  const rules = {
+    traffic: ["road", "highway", "intersection", "traffic"],
+    weather: ["weather", "rain", "snow", "storm"],
+    beach: ["beach", "coast", "bay", "ocean"],
+    city: ["city", "downtown", "urban"],
+    parking: ["parking", "garage", "lot"],
+    transport: ["airport", "station", "rail", "metro"],
+  };
+
+  const tags = Object.entries(rules)
+    .filter(([, words]) => words.some((word) => text.includes(word)))
+    .map(([tag]) => tag);
+
+  if (text.includes("youtube.com") || text.includes("youtu.be")) tags.push("youtube-stream");
+  if (text.includes("m3u8")) tags.push("hls");
+
+  return [...new Set(tags)].join(", ") || "public-camera";
+}
+
+function loadCameras() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function saveCameras(cameras) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(cameras));
+}
+
+function showFlash(message, isError = false) {
+  const flash = document.getElementById("flash");
+  flash.textContent = message;
+  flash.classList.remove("hidden", "error", "success");
+  flash.classList.add(isError ? "error" : "success");
+  setTimeout(() => flash.classList.add("hidden"), 2400);
+}
+
+function normalizeYouTubeUrl(url) {
+  if (url.includes("watch?v=")) return url.replace("watch?v=", "embed/");
+  if (url.includes("youtu.be/")) return url.replace("youtu.be/", "youtube.com/embed/");
+  return url;
+}
+
+function createPreview(camera) {
+  const wrapper = document.createElement("div");
+  if (camera.tags.includes("youtube-stream")) {
+    const iframe = document.createElement("iframe");
+    iframe.src = normalizeYouTubeUrl(camera.url);
+    iframe.title = camera.name;
+    iframe.loading = "lazy";
+    iframe.allowFullscreen = true;
+    wrapper.appendChild(iframe);
+  } else {
+    const video = document.createElement("video");
+    video.controls = true;
+    video.preload = "none";
+    const source = document.createElement("source");
+    source.src = camera.url;
+    video.appendChild(source);
+    wrapper.appendChild(video);
+  }
+  return wrapper;
+}
+
+function render() {
+  const cameras = loadCameras();
+  const grid = document.getElementById("camera-grid");
+  const template = document.getElementById("camera-card-template");
+  grid.innerHTML = "";
+
+  if (!cameras.length) {
+    grid.innerHTML = "<p>No cameras yet. Add a public link to get started.</p>";
+    return;
+  }
+
+  cameras.forEach((camera) => {
+    const fragment = template.content.cloneNode(true);
+    fragment.querySelector(".camera-name").textContent = camera.name;
+    fragment.querySelector(".camera-location").textContent = camera.location || "Not set";
+    fragment.querySelector(".camera-tags").textContent = camera.tags;
+    fragment.querySelector(".camera-notes").textContent = camera.notes;
+
+    const link = fragment.querySelector(".camera-link");
+    link.href = camera.url;
+    link.textContent = camera.url;
+
+    fragment.querySelector(".preview-slot").appendChild(createPreview(camera));
+
+    fragment.querySelector(".delete-btn").addEventListener("click", () => {
+      const updated = loadCameras().filter((item) => item.id !== camera.id);
+      saveCameras(updated);
+      render();
+      showFlash("Camera removed.");
+    });
+
+    grid.appendChild(fragment);
+  });
+}
+
+function initForm() {
+  const form = document.getElementById("camera-form");
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const camera = {
+      id: crypto.randomUUID(),
+      name: document.getElementById("name").value.trim(),
+      url: document.getElementById("url").value.trim(),
+      location: document.getElementById("location").value.trim(),
+      notes: document.getElementById("notes").value.trim(),
+    };
+
+    if (!camera.name || !camera.url.startsWith("http")) {
+      showFlash("Add a camera name and a valid http(s) URL.", true);
+      return;
+    }
+
+    camera.tags = suggestTags(camera);
+    const cameras = loadCameras();
+    cameras.unshift(camera);
+    saveCameras(cameras);
+
+    form.reset();
+    render();
+    showFlash("Camera saved.");
+  });
+}
+
+initForm();
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Public Camera Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>Public Camera Dashboard</h1>
+      <p class="notice">
+        Add only camera links you have legal permission to use or links explicitly published as public.
+      </p>
+
+      <section class="card">
+        <h2>Add camera</h2>
+        <form id="camera-form" class="form-grid">
+          <label>
+            Name
+            <input id="name" required placeholder="Downtown Crossroad" />
+          </label>
+          <label>
+            Stream URL
+            <input id="url" type="url" required placeholder="https://example.com/live.m3u8" />
+          </label>
+          <label>
+            Location
+            <input id="location" placeholder="City Center" />
+          </label>
+          <label>
+            Notes
+            <input id="notes" placeholder="Optional notes" />
+          </label>
+          <button type="submit">Add camera</button>
+        </form>
+        <p id="flash" class="flash hidden"></p>
+      </section>
+
+      <section>
+        <h2>Your cameras</h2>
+        <div id="camera-grid" class="camera-grid"></div>
+      </section>
+    </main>
+
+    <template id="camera-card-template">
+      <article class="card camera-card">
+        <header>
+          <h3 class="camera-name"></h3>
+          <span class="status">saved</span>
+        </header>
+        <p><strong>Location:</strong> <span class="camera-location"></span></p>
+        <p><strong>AI tags:</strong> <span class="camera-tags"></span></p>
+        <p><strong>URL:</strong> <a class="camera-link" target="_blank" rel="noreferrer">Open stream</a></p>
+        <div class="preview-slot"></div>
+        <p class="camera-notes notes"></p>
+        <div class="actions">
+          <button class="delete-btn danger" type="button">Delete</button>
+        </div>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,25 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+.container { max-width: 1050px; margin: 0 auto; padding: 2rem 1rem 4rem; }
+.notice { background: #1e293b; border-left: 4px solid #38bdf8; padding: .75rem 1rem; border-radius: .4rem; }
+.card { background:#111827; border:1px solid #334155; border-radius:.8rem; padding:1rem; margin:1rem 0; }
+.form-grid, .camera-grid { display:grid; gap:.75rem; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); }
+input,button { width:100%; margin-top:.25rem; border-radius:.4rem; border:1px solid #334155; background:#0b1222; color:#e2e8f0; padding:.65rem; }
+button { cursor:pointer; background:#0ea5e9; border-color:#0284c7; font-weight:600; }
+button.danger { background:#ef4444; border-color:#dc2626; }
+.camera-card header, .actions { display:flex; justify-content:space-between; gap:.5rem; }
+.status { text-transform:uppercase; font-size:.75rem; letter-spacing:.08em; color:#22c55e; }
+video,iframe { width:100%; min-height:190px; border:1px solid #334155; border-radius:.5rem; margin:.6rem 0; }
+.notes { color:#94a3b8; }
+.flash { padding:.7rem; border-radius:.4rem; margin-top:.6rem; }
+.flash.success { background:#14532d; }
+.flash.error { background:#7f1d1d; }
+.hidden { display:none; }


### PR DESCRIPTION
### Motivation
- Provide a minimal, local-first dashboard to add and preview legally public camera links without a server-side dependency.  
- Offer a lightweight "AI-style" tagging helper to auto-label streams based on metadata and URL hints so users can organize saved cameras quickly.  
- Keep the implementation dependency-light and browser-first (localStorage) so it can run with a simple static server.  

### Description
- Add a static HTML UI (`index.html`) with a form to add cameras, a card template for previews, and controls to delete entries.  
- Add client-side logic (`app.js`) that persists camera entries to `localStorage`, suggests tags from keywords/URL, renders YouTube iframes vs. direct `<video>` previews, and shows transient flash messages.  
- Add dark-themed responsive styles (`styles.css`) for the dashboard, forms, cards, and media previews.  
- Replace the repository `README.md` with usage instructions, a legal/safety notice, and notes about possible next steps for a full AI scraper.  

### Testing
- Ran a static-server smoke test using `python3 -m http.server 8000` and `curl` to verify the site served correctly, which succeeded.  
- Attempted an automated browser interaction via Playwright to capture a UI screenshot, but the browser-container interactions failed in this environment and did not produce an artifact.  
- No unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aceec81720832f8a9a7fa1d10f26d5)